### PR TITLE
Clear stale data on regionLock command

### DIFF
--- a/services/smbios/src/manager.cpp
+++ b/services/smbios/src/manager.cpp
@@ -420,6 +420,7 @@ uint8_t MDR_V1::regionLock(uint8_t u8SessionId, uint8_t regionId,
     regionS[regionId].sessionId = reqSession;
     regionS[regionId].state.lockPolicy = u8LockPolicy;
     regionS[regionId].state.regionUsed = 0;
+    memset(regionS[regionId].regionData, 0, regionS[regionId].state.regionLength);
     regionS[regionId].msTimeout = msTimeout;
     regionUsed(regionS[regionId].state.regionUsed);
     lockPolicy(regionS[regionId].state.lockPolicy);


### PR DESCRIPTION
While testing different UEFI versions new SMBIOS region size might get
smaller and so not all the contents is getting overwritten. However
other functions (notably, smbiosTypePtr) search for the entries through
the whole region and so can get confused by stale data at the end.

Fix this by doing an explicit memset() over the whole region.

Signed-off-by: Paul Fertser <fercerpav@gmail.com>
Change-Id: I6e69f51199204bf9e052ef23ed9663bb85dd527b